### PR TITLE
Update README.md to capitalize Duper in require

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Duper is an automatic proof-producing theorem prover broadly similar to Isabelle
 To use Duper in an existing Lean 4 project, first add this package as a dependency. In your lakefile.lean, add:
 
 ```lean
-require duper from git "https://github.com/leanprover-community/duper.git" @ "v0.0.5"
+require Duper from git "https://github.com/leanprover-community/duper.git" @ "v0.0.5"
 ```
 
 Then, make sure that your `lean-toolchain` file contains the same version of Lean 4 as Duper and that if your project imports [std4](https://github.com/leanprover/std4.git), then it uses the same version of std4 as the Duper branch of [Auto](https://github.com/leanprover-community/lean-auto.git). This step is necessary because Duper depends on Auto which depends on std4, so errors can arise if your project attempts to import a version of std4 different from the one imported by Duper.


### PR DESCRIPTION
I was trying to install, but I kept getting the error

```
boltonbailey@starlight drafting % lake update duper
warning: drafting: package 'Duper' was required as 'duper'
mathlib: running post-update hooks
error: dependency 'duper' not in manifest; use `lake update duper` to add it
error: mathlib: failed to fetch cache
boltonbailey@starlight drafting % lake update duper
warning: drafting: package 'Duper' was required as 'duper'
mathlib: running post-update hooks
error: dependency 'duper' not in manifest; use `lake update duper` to add it
error: mathlib: failed to fetch cache
boltonbailey@starlight drafting %
```

Jon Eugster suggested that I change the `duper` to `Duper` in the import statement and then it worked, so it seems like it should be capitalized in the instructions here.